### PR TITLE
Made DOCKER_SOCK path user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Note: You must apply `HEALTHCHECK` to your docker images first. See https://docs
 ```
 AUTOHEAL_CONTAINER_LABEL=autoheal
 AUTOHEAL_INTERVAL=5
+DOCKER_SOCK=/var/run/docker.sock
 ```
 
 ## Testing
@@ -30,6 +31,6 @@ docker build -t autoheal .
 
 docker run -d \
     -e AUTOHEAL_CONTAINER_LABEL=all \
-    -v /var/run/docker.sock:/tmp/docker.sock \
+    -v /var/run/docker.sock:/var/run/docker.sock \
     autoheal                                                                        
 ```

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -e
 
-DOCKER_SOCK=/tmp/docker.sock
+DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
 TMP_DIR=/tmp/restart
 
 if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then


### PR DESCRIPTION
Made `DOCKER_SOCK` path user configurable, and let it default to `/var/run/docker.sock`.
Fix for #3.