### PR TITLE
Listen for sigterm and exit

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -4,6 +4,13 @@ set -e
 DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
 TMP_DIR=/tmp/restart
 
+# SIGTERM-handler
+term_handler() {
+  exit 143; # 128 + 15 -- SIGTERM
+}
+
+trap 'kill ${!}; term_handler' SIGTERM
+
 if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
   
   mkdir -p $TMP_DIR


### PR DESCRIPTION
This allows to container to quickly exit on `docker stop`. Currently the stop command times out (10 seconds) and issues a kill.