### PR TITLE
Adds container name in log

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -37,13 +37,15 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
       HEALTH=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/json | jq -r .State.Health.Status)
       if [ "unhealthy" = "$HEALTH" ]; then
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
-        echo "$DATE Container ${CONTAINER:0:12} found to be unhealthy"
+        CONTAINER_NAME=$(docker inspect --format="{{.Name}}" $CONTAINER)
+        echo "$DATE Container $CONTAINER_NAME (${CONTAINER:0:12}) found to be unhealthy"
         touch "$TMP_DIR/$CONTAINER"
       fi
     done
     for CONTAINER in `ls $TMP_DIR`; do 
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
-        echo "$DATE Restarting container ${CONTAINER:0:12}"
+        CONTAINER_NAME=$(docker inspect --format="{{.Name}}" $CONTAINER)
+        echo "$DATE Restarting container $CONTAINER_NAME (${CONTAINER:0:12})"
         curl -f --no-buffer -s -XPOST --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/restart && rm "$TMP_DIR/$CONTAINER" || echo "$DATE Restarting container ${CONTAINER:0:12} failed"
     done
   done


### PR DESCRIPTION
For us, on image version updates old containers are recreated with new ids making logs not that useful.