### PR TITLE
Delete container from restart list when container name is null

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -50,8 +50,13 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
     for CONTAINER in `ls $TMP_DIR`; do 
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
         CONTAINER_NAME=$(docker_curl -XGET http://localhost/containers/${CONTAINER}/json | jq -r .Name)
-        echo "$DATE Restarting container ${CONTAINER_NAME} (${CONTAINER:0:12})"
-        docker_curl -f -XPOST http://localhost/containers/${CONTAINER}/restart && rm "$TMP_DIR/$CONTAINER" || echo "$DATE Restarting container ${CONTAINER:0:12} failed"
+        if [ "null" = "$CONTAINER_NAME" ]; then
+          echo "$DATE Delete container ${CONTAINER_NAME} (${CONTAINER:0:12}) from restart list because container name null implies container is not exists"
+          rm "$TMP_DIR/$CONTAINER"
+        else
+          echo "$DATE Restarting container ${CONTAINER_NAME} (${CONTAINER:0:12})"
+          docker_curl -f -XPOST http://localhost/containers/${CONTAINER}/restart && rm "$TMP_DIR/$CONTAINER" || echo "$DATE Restarting container ${CONTAINER:0:12} failed"
+        fi
     done
   done
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -51,7 +51,7 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
         CONTAINER_NAME=$(docker_curl -XGET http://localhost/containers/${CONTAINER}/json | jq -r .Name)
         if [ "null" = "$CONTAINER_NAME" ]; then
-          echo "$DATE Delete container ${CONTAINER_NAME} (${CONTAINER:0:12}) from restart list because container name null implies container is not exists"
+          echo "$DATE Delete container ${CONTAINER_NAME} (${CONTAINER:0:12}) from restart list because container name null implies container does not exist"
           rm "$TMP_DIR/$CONTAINER"
         else
           echo "$DATE Restarting container ${CONTAINER_NAME} (${CONTAINER:0:12})"


### PR DESCRIPTION
Delete container from restart list because container name null implies container does not exist.


When container does not exist, return of `docker_curl -XGET http://localhost/containers/${CONTAINER}/json | jq -r .Name` is null because `docker_curl -XGET http://localhost/containers/${CONTAINER}/json` return 404.


It will happen when autoheal detects an unhealthy container and touch temp container file, but before autoheal restarts container, the container is removed by another process. So autoheal can't restart this container successful and the temp container file exists forever. This will cause an infinite loop. 

See logs below:

```
14-06-2018 10:27:39 Container /test (eaad6e6c2de3) found to be unhealthy
14-06-2018 10:27:39 Restarting container /test (eaad6e6c2de3)
14-06-2018 10:27:39 Restarting container eaad6e6c2de3 failed
14-06-2018 10:27:45 Restarting container null (eaad6e6c2de3)
14-06-2018 10:27:45 Restarting container eaad6e6c2de3 failed
14-06-2018 10:27:50 Restarting container null (eaad6e6c2de3)
14-06-2018 10:27:50 Restarting container eaad6e6c2de3 failed
......
```