### PR TITLE
Added AUTOHEAL_START_PERIOD to delay the first health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ b) Set ENV `AUTOHEAL_CONTAINER_LABEL=all` to watch all running containers.
 
 c) Set ENV `AUTOHEAL_CONTAINER_LABEL` to existing label name that has the value `true`.
 
-Note: You must apply `HEALTHCHECK` to your docker images first. See https://docs.docker.com/engine/reference/builder/#/healthcheck for details.
+Note: You must apply `HEALTHCHECK` to your docker images first. See https://docs.docker.com/engine/reference/builder/#healthcheck for details.
 
 ## ENV Defaults
 ```
 AUTOHEAL_CONTAINER_LABEL=autoheal
 AUTOHEAL_INTERVAL=5   # check every 5 seconds
+AUTOHEAL_START_PERIOD=0   # wait 0 second before first health check
 DOCKER_SOCK=/var/run/docker.sock
 ```
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -33,7 +33,9 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
     }
   fi
 
-  echo "Monitoring containers for unhealthy status"
+  echo "Monitoring containers for unhealthy status in ${AUTOHEAL_START_PERIOD} second(s)"
+  sleep ${AUTOHEAL_START_PERIOD:=0}
+
   while true; do
     sleep ${AUTOHEAL_INTERVAL:=5}
 


### PR DESCRIPTION
Using this container with web application running in tomcat, which takes time to start (around 4 minutes). It checks for health too early, causing container to restart. Unfortunately the war file don't have time to be totally extracted in tomcat, resulting in an infinite cycle of unhealth/start. And I don't want to increase the AUTOHEAL_INTERVAL to a higher value because it wouldn't make sense.

I don't own dockerfile and compose versions, thus I can't use the ```start-period``` from docker because it's not known... Adding this new property could help to us in that situation.

[Here](https://github.com/docker/compose/issues/5177) is related issue with docker/compose