### PR TITLE
Update docker-entrypoint

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -26,8 +26,9 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
     labelFilter=",\"label\":\[\"${AUTOHEAL_CONTAINER_LABEL:=autoheal}=true\"\]"
   fi
 
+  AUTOHEAL_START_PERIOD=${AUTOHEAL_START_PERIOD:=0}
   echo "Monitoring containers for unhealthy status in ${AUTOHEAL_START_PERIOD} second(s)"
-  sleep ${AUTOHEAL_START_PERIOD:=0}
+  sleep ${AUTOHEAL_START_PERIOD}
 
   while true; do
     sleep ${AUTOHEAL_INTERVAL:=5}


### PR DESCRIPTION
When using the default start period, autoheal always prints `Monitoring containers for unhealthy status in  second(s)`