### PR TITLE
Exit if right most command fails in pipe

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
+
 set -e
+set -o pipefail
 
 DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
 CURL_TIMEOUT=${CURL_TIMEOUT:-30}


### PR DESCRIPTION
The bash shell normally only looks at the exit code of the last command of a pipeline. This behavior is not ideal as it causes the -e option to only be able to act on the exit code of a pipeline’s last command.  `set -o pipefail` sets the exit code of a pipeline to that of the rightmost command to exit with a non-zero status, or to zero if all commands of the pipeline exit successfully.

