### PR TITLE
Add global and per container stop timeouts ; minor doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-autoheal
 
 Monitor and restart unhealthy docker containers. 
-This functionality was propose to be included with the addition of `HEALTHCHECK`, however didn't make the cut.
+This functionality was proposed to be included with the addition of `HEALTHCHECK`, however didn't make the cut.
 This container is a stand-in till there is native support for `--exit-on-unhealthy` https://github.com/docker/docker/pull/22719.
 
 ## Supported tags and Dockerfile links
@@ -30,8 +30,15 @@ Note: You must apply `HEALTHCHECK` to your docker images first. See https://docs
 ```
 AUTOHEAL_CONTAINER_LABEL=autoheal
 AUTOHEAL_INTERVAL=5   # check every 5 seconds
-AUTOHEAL_START_PERIOD=0   # wait 0 second before first health check
-DOCKER_SOCK=/var/run/docker.sock
+AUTOHEAL_START_PERIOD=0   # wait 0 seconds before first health check
+AUTOHEAL_DEFAULT_STOP_TIMEOUT=10   # Docker waits max 10 seconds (the Docker default) for a container to stop before killing during restarts (container overridable via label, see below)
+DOCKER_SOCK=/var/run/docker.sock   # Unix socket for curl requests to Docker API
+CURL_TIMEOUT=30     # --max-time seconds for curl requests to Docker API
+```
+
+### Optional Container Labels
+```
+autoheal.stop.timeout=20        # Per containers override for stop timeout seconds during restart
 ```
 
 ## Testing

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -26,22 +26,25 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
     labelFilter=",\"label\":\[\"${AUTOHEAL_CONTAINER_LABEL:=autoheal}=true\"\]"
   fi
 
-  echo "Monitoring containers for unhealthy status in ${AUTOHEAL_START_PERIOD} second(s)"
+  echo "Monitoring containers for unhealthy status in ${AUTOHEAL_START_PERIOD:=0} second(s)"
   sleep ${AUTOHEAL_START_PERIOD:=0}
 
   while true; do
     sleep ${AUTOHEAL_INTERVAL:=5}
     
     apiUrl="http://localhost/containers/json?filters=\{\"health\":\[\"unhealthy\"\]${labelFilter}\}"
-    docker_curl "$apiUrl" | jq -r 'foreach .[] as $CONTAINER([];[]; $CONTAINER | .Id, .Names[0])' | \
-    while read -r CONTAINER_ID && read -r CONTAINER_NAME; do
+    stopTimeout=".Labels[\"autoheal.stop.timeout\"] // ${AUTOHEAL_DEFAULT_STOP_TIMEOUT:-10}"
+    docker_curl "$apiUrl" | \
+    jq -r "foreach .[] as \$CONTAINER([];[]; \$CONTAINER | .Id, .Names[0], $stopTimeout )" | \
+    while read -r CONTAINER_ID && read -r CONTAINER_NAME && read -r TIMEOUT; do
         CONTAINER_SHORT_ID=${CONTAINER_ID:0:12}
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
         if [ "null" = "$CONTAINER_NAME" ]; then
           echo "$DATE Container name of ($CONTAINER_SHORT_ID) is null, which implies container does not exist - don't restart"
         else
-          echo "$DATE Container ${CONTAINER_NAME} ($CONTAINER_SHORT_ID) found to be unhealthy - Restarting container now"
-          docker_curl -f -XPOST http://localhost/containers/${CONTAINER_ID}/restart || echo "$DATE Restarting container $CONTAINER_SHORT_ID failed"
+          echo "$DATE Container ${CONTAINER_NAME} ($CONTAINER_SHORT_ID) found to be unhealthy - Restarting container now with ${TIMEOUT}s timeout"
+          docker_curl -f -XPOST "http://localhost/containers/${CONTAINER_ID}/restart?t=${TIMEOUT}" \
+            || echo "$DATE Restarting container $CONTAINER_SHORT_ID failed"
         fi
     done
   done


### PR DESCRIPTION
- Allow specifying timeout parameter in Docker container restart API seen here: https://docs.docker.com/engine/api/v1.25/#operation/ContainerRestart
- Can set global default for containers by env var on autoheal container
- Can set per container via label
- Useful for containers that may need to clean up more than default 10s (in my case, e.g. postgres)