### PR TITLE
Add multiarch support + Daily builds with GitHub Actions

### DIFF
--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions CI
+
+on:
+  push:
+  schedule:
+    - cron:  '0 6 * * *'
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Docker login
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build docker container
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/pschmitt/ci-setup-docker-buildx/master/setup.sh | bash
+          ./buildx.sh

--- a/buildx.sh
+++ b/buildx.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+IMAGE_NAME="willfarrell/autoheal"
+
+usage() {
+  echo "Usage: $0"
+}
+
+array_join() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+get_available_architectures() {
+  local image="$1"
+  local tag="${2:-latest}"
+
+  docker buildx imagetools inspect --raw "${image}:${tag}" | \
+    jq -r '.manifests[].platform | .os + "/" + .architecture + "/" + .variant' | \
+    sed 's#/$##' | sort
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+  set -ex
+
+  cd "$(readlink -f "$(dirname "$0")")" || exit 9
+
+  read -r base_image base_tag <<< \
+    "$(sed -nr 's/^FROM\s+([^:]+):?((\w+).*)\s*$/\1 \3/p' Dockerfile | head -1)"
+  # shellcheck disable=2207
+  platforms=($(get_available_architectures "$base_image" "$base_tag"))
+
+  PUSH_IMAGE=true
+  BUILD_TYPE=manual
+
+  if [[ "$TRAVIS" == "true" ]]
+  then
+    BUILD_TYPE=travis
+  elif [[ "$GITHUB_ACTIONS" == "true" ]]
+  then
+    BUILD_TYPE=github
+  fi
+
+  docker buildx build \
+    --platform "$(array_join "," "${platforms[@]}")" \
+    --output "type=image,push=${PUSH_IMAGE}" \
+    --no-cache \
+    --label=build-type="$BUILD_TYPE" \
+    --label=built-on="$HOSTNAME" \
+    --tag "${IMAGE_NAME}:latest" \
+    .
+fi


### PR DESCRIPTION
# Changes
2 things:
- multiarch support \o/
- Daily builds

I enabled this on [my fork](https://github.com/pschmitt/docker-autoheal/tree/multiarch) already.
Build logs are available [here](https://github.com/pschmitt/docker-autoheal/actions?query=workflow%3A%22GitHub+Actions+CI%22).
The resulting images are pushed to the [Docker Hub registry](https://hub.docker.com/r/pschmitt/autoheal/tags).

# Multiarch
This PR will build an image for all available architectures of the base container image. It's future proof if you ever decide the change the `FROM`. I'd suggest to change it to `alpine:latest` btw since it is very, very unlikely to break (the entrypoint is just a shell script with almost no dependencies after all).

# Requirements for this work
@willfarrell you need to set the following [2 secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) at the repo level to enable pushes to the Docker Hub
- `DOCKER_USERNAME`: You Docker Hub username (`willfarrell` I presume)
- `DOCKER_PASSWORD`: Your Docker Hub password (duh)

# Notes
- If the ` curl -fsSL https://raw.githubusercontent.com/pschmitt/ci-setup-docker-buildx/master/setup.sh | bash` part bothers, which I can understand, feel free to include the [actual file](https://github.com/pschmitt/ci-setup-docker-buildx/blob/master/setup.sh) in this here repo and replace the `curl | bash` part with `./setup.sh`
The script does nothing but setup the build environment ([docker buildx](https://github.com/docker/buildx))
- This addresses #26 
- The CI part depends on #41 for builds to pass
