### PR TITLE
Rebase on alpine latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG arch=x86_64
-FROM multiarch/alpine:${arch}-v3.8
+FROM alpine:3.11
 
 RUN apk add --no-cache curl jq
 


### PR DESCRIPTION
As mentionned in #40 rebasing on alpine:latest shouldn't be a problem .. and would make the `buildx.sh` script produce multiarch images ;)