### PR TITLE
Hide START_PERIOD=0 from log

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -35,7 +35,7 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
   fi
 
   AUTOHEAL_START_PERIOD=${AUTOHEAL_START_PERIOD:=0}
-  echo "Monitoring containers for unhealthy status in ${AUTOHEAL_START_PERIOD} second(s)"
+  echo "Monitoring containers for unhealthy status $([ "${AUTOHEAL_START_PERIOD}" != 0 ] && echo "in ${AUTOHEAL_START_PERIOD} second(s)")"
   sleep ${AUTOHEAL_START_PERIOD}
 
   while true; do


### PR DESCRIPTION
Hey, this is pure eye candy. No added functionality. Feel free to decide against the addition.