### PR TITLE
ci: Use upstream actions

### DIFF
--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -2,6 +2,8 @@ name: GitHub Actions CI
 
 on:
   push:
+    branches:
+      - main
   schedule:
     - cron:  '0 6 * * *'
 

--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -10,19 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@master
-        with:
-          ref: ${{ github.ref }}
+        uses: actions/checkout@v2
 
-      - name: Docker login
-        uses: azure/docker-login@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build docker container
-        env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
         run: |
-          curl -fsSL https://raw.githubusercontent.com/pschmitt/ci-setup-docker-buildx/master/setup.sh |
-          bash ./buildx.sh
+          ./buildx.sh


### PR DESCRIPTION
A lot has changed in GitHub Actions land. Docker published a bunch of Actions.

This effectively removes the need for my  weird `setup.sh` thingy.