### PR TITLE
make tests compatible with docker servers that run multiple projects

### DIFF
--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,1 @@
+AUTOHEAL_CONTAINER_LABEL=autoheal-test

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,3 +11,14 @@ Currently setup to a very basic exit 1 on invalid restart and exit 0 on valid re
 cd tests
 ./tests.sh
 ```
+
+## Run tests in CI
+```
+cd tests
+export "AUTOHEAL_CONTAINER_LABEL=autoheal-123456"
+./tests.sh "MY_UNIQUE_BUILD_NUMBER_123456"
+```
+
+This enables the tests to only restart containers within the test spec by using
+unique docker-compose project names and autoheal labels (as long as you replace
+123456 by a unique number)

--- a/tests/docker-compose.autoheal.yml
+++ b/tests/docker-compose.autoheal.yml
@@ -3,9 +3,10 @@ version: '3.7'
 services:
 
   watch-autoheal:
-    container_name: watch-autoheal
     build: watch-autoheal
     restart: "no"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      COMPOSE_PROJECT_NAME: $COMPOSE_PROJECT_NAME
     network_mode: none

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,10 +3,12 @@ version: '3.7'
 services:
 
   should-keep-restarting:
+    # this container should be restarted by autoheal because its unhealthy and has the autoheal label
     image: alpine
-    container_name: should-keep-restarting
     network_mode: none
     restart: "no"
+    labels:
+      - "$AUTOHEAL_CONTAINER_LABEL=true"
     healthcheck:
       test: exit 1
       interval: 3s
@@ -15,11 +17,13 @@ services:
       start_period: 5s
     command: tail -f /dev/null
 
-  shouldnt-restart:
+  shouldnt-restart-healthy:
+    # this container shouldn't be restarted by autoheal because its healthy
     image: alpine
-    container_name: shouldnt-restart
     network_mode: none
     restart: "no"
+    labels:
+      - "$AUTOHEAL_CONTAINER_LABEL=true"
     healthcheck:
       test: exit 0
       interval: 2s
@@ -28,14 +32,25 @@ services:
       start_period: 1s
     command: tail -f /dev/null
 
+  shouldnt-restart-no-label:
+    # this container shouldn't be restarted by autoheal because its missing the autoheal label
+    image: alpine
+    network_mode: none
+    restart: "no"
+    healthcheck:
+      test: exit 1
+      interval: 3s
+      timeout: 1s
+      retries: 1
+      start_period: 5s
+    command: tail -f /dev/null
 
   autoheal:
-    container_name: autoheal
     build:
       context: ../
     restart: unless-stopped
     environment:
-      AUTOHEAL_CONTAINER_LABEL: "all"
+      AUTOHEAL_CONTAINER_LABEL: "${AUTOHEAL_CONTAINER_LABEL:-all}"
       AUTOHEAL_INTERVAL: "10"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-COMPOSE_PROJECT_NAME=autoheal-test
+COMPOSE_PROJECT_NAME=${1:-autoheal-test}
+export COMPOSE_PROJECT_NAME
 
 function cleanup()
 {
     exit_status=$?
     echo "exit was $exit_status"
-    docker-compose -f docker-compose.autoheal.yml -f docker-compose.yml rm -f || true
+    # stop autoheal first, to stop it restarting the test containers while we try to stop them
+    docker-compose stop autoheal
+    docker-compose -f docker-compose.autoheal.yml -f docker-compose.yml down || true
     exit "$exit_status"
 }
 trap cleanup EXIT

--- a/tests/watch-autoheal/entrypoint.sh
+++ b/tests/watch-autoheal/entrypoint.sh
@@ -3,14 +3,17 @@ set -euxo pipefail
 
 listenToDockerEvents()
 {
-docker events --filter 'container=should-keep-restarting' --filter 'container=shouldnt-restart' --filter 'event=restart' | while read LOGLINE
-do
-  echo "$LOGLINE"
-  # may be more elaborate checks here.
-   [[ "${LOGLINE}" == *"container restart "*"name=shouldnt-restart"* ]] && echo "ERR: No restarts expected on shouldnt-restart container!" && pkill -9 docker && exit 1
-   [[ "${LOGLINE}" == *"container restart "*"name=should-keep-restarting"* ]] && echo "OK: Expected restart on should-keep-restarting container!" && pkill -9 docker && exit 0
-done
-
+  local expected_restarts
+  local LOGLINE
+  expected_restarts=0
+  docker events --filter 'com.docker.compose.service=should-keep-restarting' --filter 'com.docker.compose.service=shouldnt-restart-*' --filter 'event=restart' | while read -r LOGLINE
+  do
+    echo "$LOGLINE"
+    # may be more elaborate checks here.
+    [[ $LOGLINE == *"container restart "*"com.docker.compose.service=shouldnt-restart-"* && $LOGLINE == *"com.docker.compose.project=$COMPOSE_PROJECT_NAME"* ]] && echo "ERR: No restarts expected on shouldnt-restart-* containers!" 1>&2 && pkill -9 docker && exit 1
+    [[ $LOGLINE == *"container restart "*"com.docker.compose.service=should-keep-restarting"* && $LOGLINE == *"com.docker.compose.project=$COMPOSE_PROJECT_NAME"* ]] && echo "OK: Expected restart on should-keep-restarting container!" && pkill -9 docker && expected_restarts=$((expected_restarts + 1))
+    [[ $expected_restarts == 1 ]] && echo "OK: All expected restarts happened" && exit 0
+  done
 }
 
 export -f listenToDockerEvents


### PR DESCRIPTION
currently the tests running with `AUTOHEAL_CONTAINER_LABEL: "all"` might affect other projects running on the same server

e.g. on our CI we run multiple tests in parallel for multiple projects if the autoheal tests tries to repair all containers that might affect other tests. (testing healthchecks of other images)

with this change one can define a unique AUTOHEAL_CONTAINER_LABEL and export it before the tests, so the autoheal test only restart containers that are created by the test. and define a unique docker-compose project name that makes it easier to stop and delete the remaining containers after the tests in a CI cleanup stage.

@hasnat might i ask you to have a look?

Info @wt-io-it
