### PR TITLE
upgrade alpine to 3.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.13.5
 
 RUN apk add --no-cache curl jq
 


### PR DESCRIPTION
why not 3.14? it would break CI

https://alpinelinux.org/posts/Alpine-3.14.0-released.html

> The faccessat2 syscall has been enabled in musl. This can result in issues on docker hosts with older versions of docker (<20.10.0) and libseccomp (<2.4.4), which blocks this syscall.

and close #63
