### PR TITLE
Apprise notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV AUTOHEAL_CONTAINER_LABEL=autoheal \
     AUTOHEAL_DEFAULT_STOP_TIMEOUT=10 \
     DOCKER_SOCK=/var/run/docker.sock \
     CURL_TIMEOUT=30 \
-    WEBHOOK_URL=""
+    WEBHOOK_URL="" \
+    APPRISE_URL=""
 
 HEALTHCHECK --interval=5s CMD pgrep -f autoheal || exit 1
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ If you need the timezone to match the local machine, you can map the `/etc/local
 docker run ... -v /etc/localtime:/etc/localtime:ro
 ```
 
+### Apprise configuration
+a) Start the Apprise docker container. See: https://hub.docker.com/r/caronc/apprise
+
+b) Create an Apprise configuration for Autoheal to use:
+http://localhost:8000/cfg/autoheal
+
+See the Apprise wiki for configuration details: https://github.com/caronc/apprise/wiki
+
+c) Set the `APPRISE_URL` environment variable to use the Apprise configuration: 
+`APPRISE_URL="http://localhost:8000/notify/autoheal"`
 
 ## ENV Defaults
 ```
@@ -61,6 +71,7 @@ AUTOHEAL_DEFAULT_STOP_TIMEOUT=10   # Docker waits max 10 seconds (the Docker def
 DOCKER_SOCK=/var/run/docker.sock   # Unix socket for curl requests to Docker API
 CURL_TIMEOUT=30     # --max-time seconds for curl requests to Docker API
 WEBHOOK_URL=""    # post message to the webhook if a container was restarted (or restart failed)
+APPRISE_URL=""    # post message to Apprise if a container was restarted (or restart failed)
 ```
 
 ### Optional Container Labels

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -64,13 +64,13 @@ notify_webhook() {
   if [ -n "$WEBHOOK_URL" ]
   then
     # execute webhook requests as background process to prevent healer from blocking
-    curl -X POST -H "Content-type: application/json" -d "$(generate_webhook_payload $text)"  $WEBHOOK_URL
+    curl -s -X POST -H "Content-type: application/json" -d "$(generate_webhook_payload $text)"  $WEBHOOK_URL
   fi
 
   if [ -n "$APPRISE_URL" ]
   then
     # execute webhook requests as background process to prevent healer from blocking
-    curl -X POST -H "Content-type: application/json" -d "$(generate_apprise_payload $text)"  $APPRISE_URL
+    curl -s -X POST -H "Content-type: application/json" -d "$(generate_apprise_payload $text)"  $APPRISE_URL
   fi
 }
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -8,6 +8,7 @@ DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
 UNIX_SOCK=""
 CURL_TIMEOUT=${CURL_TIMEOUT:-30}
 WEBHOOK_URL=${WEBHOOK_URL:-""}
+APPRISE_URL=${APPRISE_URL:-""}
 
 # only use unix domain socket if no TCP endpoint is defined
 case "${DOCKER_SOCK}" in
@@ -65,6 +66,12 @@ notify_webhook() {
     # execute webhook requests as background process to prevent healer from blocking
     curl -X POST -H "Content-type: application/json" -d "$(generate_webhook_payload $text)"  $WEBHOOK_URL
   fi
+
+  if [ -n "$APPRISE_URL" ]
+  then
+    # execute webhook requests as background process to prevent healer from blocking
+    curl -X POST -H "Content-type: application/json" -d "$(generate_apprise_payload $text)"  $APPRISE_URL
+  fi
 }
 
 # https://towardsdatascience.com/proper-ways-to-pass-environment-variables-in-json-for-curl-post-f797d2698bf3
@@ -73,6 +80,16 @@ generate_webhook_payload() {
   cat <<EOF
 {
   "text":"$text"
+} 
+EOF
+}
+
+generate_apprise_payload() {
+  local text="$@"
+  cat <<EOF
+{
+  "title":"Autoheal",
+  "body":"$text"
 } 
 EOF
 }


### PR DESCRIPTION
Adds support for notifying of container restarts via Apprise.

Apprise can be configured with a wide range of notification services including: eMail, Slack, MS Teams, Gotify, Pushover, etc. See the [full list](https://github.com/caronc/apprise/wiki#notification-services) for more. Multiple services can be configured for notification at the same time.