### PR TITLE
Update docker-entrypoint

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -72,7 +72,7 @@ generate_webhook_payload() {
   local text="$@"
   cat <<EOF
 {
-  "text":"$text"
+  "content":"$text"
 } 
 EOF
 }


### PR DESCRIPTION
line 75
using `"text":"$text"` fails, but if you change it to `"content":"$text"` it works