### PR TITLE
Feature: change the key in the json body of the webhook message to use an environment variable 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV AUTOHEAL_CONTAINER_LABEL=autoheal \
     AUTOHEAL_DEFAULT_STOP_TIMEOUT=10 \
     DOCKER_SOCK=/var/run/docker.sock \
     CURL_TIMEOUT=30 \
-    WEBHOOK_URL=""
+    WEBHOOK_URL="" \
+    WEBHOOK_JSON_KEY="text"
 
 HEALTHCHECK --interval=5s CMD pgrep -f autoheal || exit 1
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AUTOHEAL_DEFAULT_STOP_TIMEOUT=10   # Docker waits max 10 seconds (the Docker def
 DOCKER_SOCK=/var/run/docker.sock   # Unix socket for curl requests to Docker API
 CURL_TIMEOUT=30     # --max-time seconds for curl requests to Docker API
 WEBHOOK_URL=""    # post message to the webhook if a container was restarted (or restart failed)
+WEBHOOK_JSON_KEY="text"    # the key to use for the message in the json body of the request to the webhook url
 ```
 
 ### Optional Container Labels

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -8,6 +8,7 @@ DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
 UNIX_SOCK=""
 CURL_TIMEOUT=${CURL_TIMEOUT:-30}
 WEBHOOK_URL=${WEBHOOK_URL:-""}
+WEBHOOK_JSON_KEY=${WEBHOOK_JSON_KEY:-"text"}
 
 # only use unix domain socket if no TCP endpoint is defined
 case "${DOCKER_SOCK}" in
@@ -72,7 +73,7 @@ generate_webhook_payload() {
   local text="$@"
   cat <<EOF
 {
-  "text":"$text"
+  "$WEBHOOK_JSON_KEY":"$text"
 } 
 EOF
 }


### PR DESCRIPTION
As discussed in PR #75, The key used in the webhook body can be a variable to allow the user to adjust it to their webhook provider. so I changed the body of the webhook request from
```json
"text":"$text"
```
to 
```json
"$WEBHOOK_JSON_KEY":"$text"
```

Let me know if anything should be changed or if the change isn't acceptable. 
And thanks for making this awesome repo.