### PR TITLE
Allow specifying a script to be executed after restarting a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.5
+FROM alpine:3.17
 
 RUN apk add --no-cache curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV AUTOHEAL_CONTAINER_LABEL=autoheal \
     AUTOHEAL_DEFAULT_STOP_TIMEOUT=10 \
     DOCKER_SOCK=/var/run/docker.sock \
     CURL_TIMEOUT=30 \
-    WEBHOOK_URL=""
+    WEBHOOK_URL="" \
+    POST_RESTART_SCRIPT=""
 
 HEALTHCHECK --interval=5s CMD pgrep -f autoheal || exit 1
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Autoheal
 
-Monitor and restart unhealthy docker containers. 
+Monitor and restart unhealthy docker containers.
 This functionality was proposed to be included with the addition of `HEALTHCHECK`, however didn't make the cut.
 This container is a stand-in till there is native support for `--exit-on-unhealthy` https://github.com/docker/docker/pull/22719.
 
@@ -33,7 +33,7 @@ docker run -d \
 ```
 a) Apply the label `autoheal=true` to your container to have it watched.
 
-b) Set ENV `AUTOHEAL_CONTAINER_LABEL=all` to watch all running containers. 
+b) Set ENV `AUTOHEAL_CONTAINER_LABEL=all` to watch all running containers.
 
 c) Set ENV `AUTOHEAL_CONTAINER_LABEL` to existing label name that has the value `true`.
 
@@ -61,11 +61,29 @@ AUTOHEAL_DEFAULT_STOP_TIMEOUT=10   # Docker waits max 10 seconds (the Docker def
 DOCKER_SOCK=/var/run/docker.sock   # Unix socket for curl requests to Docker API
 CURL_TIMEOUT=30     # --max-time seconds for curl requests to Docker API
 WEBHOOK_URL=""    # post message to the webhook if a container was restarted (or restart failed)
+POST_RESTART_SCRIPT=""    # Run the specified script if a container was restarted (or restart failed). Script is run from inside the container. Make sure to mount a host directory with the script you want to run. e.g. `-v ./scripts:/scripts`
 ```
 
 ### Optional Container Labels
 ```
 autoheal.stop.timeout=20        # Per containers override for stop timeout seconds during restart
+```
+
+### Post-Restart Script
+
+Here's an example of how you can execute a script after a restart.
+
+The following values are passed as arguments: `CONTAINER_NAME`, `CONTAINER_SHORT_ID`, `CONTAINER_STATE`, `RESTART_TIMEOUT`.
+
+```bash
+docker build -t autoheal .
+
+docker run -d \
+    -e AUTOHEAL_CONTAINER_LABEL=all \
+    -e POST_RESTART_SCRIPT=/scripts/post_restart.sh \
+    -v ./scripts:/scripts \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    autoheal
 ```
 
 ## Testing
@@ -74,6 +92,7 @@ docker build -t autoheal .
 
 docker run -d \
     -e AUTOHEAL_CONTAINER_LABEL=all \
+    -e POST_RESTART_SCRIPT=/scripts/post_restart.sh
     -v /var/run/docker.sock:/var/run/docker.sock \
-    autoheal                                                                        
+    autoheal
 ```

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -67,13 +67,21 @@ notify_webhook() {
   fi
 }
 
+notify_post_restart_script() {
+  if [ -n "$POST_RESTART_SCRIPT" ]
+  then
+    # execute post restart script as background process to prevent healer from blocking
+    $POST_RESTART_SCRIPT "$@" &
+  fi
+}
+
 # https://towardsdatascience.com/proper-ways-to-pass-environment-variables-in-json-for-curl-post-f797d2698bf3
 generate_webhook_payload() {
   local text="$@"
   cat <<EOF
 {
   "text":"$text"
-} 
+}
 EOF
 }
 
@@ -116,9 +124,10 @@ if [ "$1" = "autoheal" ] && [ -e "$DOCKER_SOCK" ];then
         then
           echo "$DATE Restarting container $CONTAINER_SHORT_ID failed" >&2
           notify_webhook "Container ${CONTAINER_NAME:1} (${CONTAINER_SHORT_ID}) found to be unhealthy. Failed to restart the container!" &
-        else 
+        else
           notify_webhook "Container ${CONTAINER_NAME:1} (${CONTAINER_SHORT_ID}) found to be unhealthy. Successfully restarted the container!" &
         fi
+        notify_post_restart_script "$CONTAINER_NAME" "$CONTAINER_SHORT_ID" "$CONTAINER_STATE" "$TIMEOUT" &
       fi
     done
     sleep "$AUTOHEAL_INTERVAL"


### PR DESCRIPTION
This gives more flexibility than a simple webhook.