### PR TITLE
Only monitor running containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ AUTOHEAL_CONTAINER_LABEL=autoheal
 AUTOHEAL_INTERVAL=5   # check every 5 seconds
 AUTOHEAL_START_PERIOD=0   # wait 0 seconds before first health check
 AUTOHEAL_DEFAULT_STOP_TIMEOUT=10   # Docker waits max 10 seconds (the Docker default) for a container to stop before killing during restarts (container overridable via label, see below)
+AUTOHEAL_ONLY_MONITOR_RUNNING=false # All containers monitored by default. Set this to true to only monitor running containers. This will result in Paused contaners being ignored.
 DOCKER_SOCK=/var/run/docker.sock   # Unix socket for curl requests to Docker API
 CURL_TIMEOUT=30     # --max-time seconds for curl requests to Docker API
 WEBHOOK_URL=""    # post message to the webhook if a container was restarted (or restart failed)

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -45,7 +45,13 @@ get_container_info() {
   else
     label_filter=",\"label\":\[\"${AUTOHEAL_CONTAINER_LABEL}=true\"\]"
   fi
-  url="${HTTP_ENDPOINT}/containers/json?filters=\{\"health\":\[\"unhealthy\"\]${label_filter}\}"
+  if [ "${AUTOHEAL_ONLY_MONITOR_RUNNING:=false}" = true ]
+  then
+    running_filter=""
+  else
+    running_filter=",\"state\":\[\"runing\"\]"
+  fi
+  url="${HTTP_ENDPOINT}/containers/json?filters=\{\"health\":\[\"unhealthy\"\]${label_filter}${running_filter}\}"
   docker_curl "$url"
 }
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -50,7 +50,7 @@ get_container_info() {
   then
     running_filter=""
   else
-    running_filter=",\"status\":\[\"runing\"\]"
+    running_filter=",\"status\":\[\"running\"\]"
   fi
   url="${HTTP_ENDPOINT}/containers/json?filters=\{\"health\":\[\"unhealthy\"\]${label_filter}${running_filter}\}"
   docker_curl "$url"

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -25,6 +25,7 @@ AUTOHEAL_CONTAINER_LABEL=${AUTOHEAL_CONTAINER_LABEL:-autoheal}
 AUTOHEAL_START_PERIOD=${AUTOHEAL_START_PERIOD:-0}
 AUTOHEAL_INTERVAL=${AUTOHEAL_INTERVAL:-5}
 AUTOHEAL_DEFAULT_STOP_TIMEOUT=${AUTOHEAL_DEFAULT_STOP_TIMEOUT:-10}
+AUTOHEAL_ONLY_MONITOR_RUNNING=${AUTOHEAL_ONLY_MONITOR_RUNNING:-false}
 
 docker_curl() {
   curl --max-time "${CURL_TIMEOUT}" --no-buffer -s \
@@ -45,7 +46,7 @@ get_container_info() {
   else
     label_filter=",\"label\":\[\"${AUTOHEAL_CONTAINER_LABEL}=true\"\]"
   fi
-  if [ "${AUTOHEAL_ONLY_MONITOR_RUNNING:=false}" = true ]
+  if [ "$AUTOHEAL_ONLY_MONITOR_RUNNING" = false ]
   then
     running_filter=""
   else

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -50,7 +50,7 @@ get_container_info() {
   then
     running_filter=""
   else
-    running_filter=",\"state\":\[\"runing\"\]"
+    running_filter=",\"status\":\[\"runing\"\]"
   fi
   url="${HTTP_ENDPOINT}/containers/json?filters=\{\"health\":\[\"unhealthy\"\]${label_filter}${running_filter}\}"
   docker_curl "$url"


### PR DESCRIPTION
This change means that containers that are not running (stopping, starting, created, exited, dead and paused) will be filtered out.

It prevents paused containers from being automatically restarted.