### PR TITLE
Rework of alpine version tagging for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:latest
 
-FROM alpine:3.18.3
+ARG ALPINE_VERSION=3.18
+
+FROM alpine:$ALPINE_VERSION
 
 RUN apk add --no-cache curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG ALPINE_VERSION=3.18
 
-FROM alpine:$ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache curl jq
 


### PR DESCRIPTION
# Dockerfile updates

- Added `ALPINE_VERSION` Argument (defaults to `3.18`).
This will allow to choose alpine version to create multiple builds as explained in #114 

# (TODO) Github CI updates

With this update the github ci script could be updated to push multiples tags on every release.

Resolve #114 