### PR TITLE
Modify SIGTERM trap to avoid segfaults

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -125,7 +125,7 @@ term_handler() {
 }
 
 # shellcheck disable=2039
-trap 'kill $$; term_handler' SIGTERM
+trap 'kill $!; term_handler' SIGTERM
 
 if [ "$1" = "autoheal" ]
 then


### PR DESCRIPTION
Fixes #127 

Currently, the trap kills the main process and tries to call the signal handler (`term_handler`); this seems to cause a segmentation fault, which is being logged to the host's syslog.

This update is a simple change to kill the most recent background process (if any) instead, and then calls `term_handler`, which will terminate the main process. With this change, no segfault errors are logged in the host machine.