### PR TITLE
bugfix: generating an error message if docker socket is not writeable

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -129,7 +129,7 @@ trap 'kill $$; term_handler' SIGTERM
 
 if [ "$1" = "autoheal" ]
 then
-  if [ -n "$UNIX_SOCK" ] && ! [ -S "$DOCKER_SOCK" ]
+  if [ -n "$UNIX_SOCK" ] && ! [ -S "$DOCKER_SOCK" ] && [ -w "$DOCKER_SOCK" ]
   then
     echo "unix socket is currently not available" >&2
     exit 1

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -129,7 +129,7 @@ trap 'kill $$; term_handler' SIGTERM
 
 if [ "$1" = "autoheal" ]
 then
-  if [ -n "$UNIX_SOCK" ] && ! [ -S "$DOCKER_SOCK" ] && [ -w "$DOCKER_SOCK" ]
+  if [[ -n "$UNIX_SOCK" && ( ! -S "$DOCKER_SOCK" || ! -w "$DOCKER_SOCK" ) ]]; then
   then
     echo "unix socket is currently not available" >&2
     exit 1


### PR DESCRIPTION
previous to this bugfix, if the socket is not writeable, the docker-autheal container was just restarting, not restarting container surveyed (main task) and not giving any error message.